### PR TITLE
esp-open-sdk stdint.h compatability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,14 @@ EXTRA_INCDIR	= ./include \
 
 # compiler flags using during compilation of source files
 CFLAGS		= -Os -ggdb -std=c99 -Werror -Wpointer-arith -Wundef -Wall -Wl,-EL -fno-inline-functions \
-		-nostdlib -mlongcalls -mtext-section-literals  -D__ets__ -DICACHE_FLASH -D_STDINT_H \
+		-nostdlib -mlongcalls -mtext-section-literals  -D__ets__ -DICACHE_FLASH \
 		-Wno-address
+
+ifeq ($(USE_OPENSDK),1)
+CFLAGS		+= -DUSE_OPENSDK
+else
+CFLAGS		+= -D_STDINT_H
+endif
 
 # various paths from the SDK used in this project
 SDK_LIBDIR	= lib


### PR DESCRIPTION
esp-open-sdk patches c_types.h for C99 compatibility, and -D_STDINT_H conflicts with this.  This introduces a Makefile variable to conditionally define _STDINT_H
