### PR TITLE
add missing quotes for USE_OPENSDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ vecho := @echo
 endif
 
 
-ifeq ($(USE_OPENSDK),"yes")
+ifeq ("$(USE_OPENSDK)","yes")
 CFLAGS		+= -DUSE_OPENSDK
 else
 CFLAGS		+= -D_STDINT_H


### PR DESCRIPTION
Woops, quotes are needed for the string version to work.  This also needs to be applied to esphttpd.  Thanks Sprite_tm :)
