### PR TITLE
fixes to espconn handling

### DIFF
--- a/core/httpd.c
+++ b/core/httpd.c
@@ -85,7 +85,7 @@ static HttpdConnData ICACHE_FLASH_ATTR *httpdFindConnData(void *arg) {
 	for (int i=0; i<MAX_CONN; i++) {
 		if (connData[i].remote_port == espconn->proto.tcp->remote_port &&
 						os_memcmp(connData[i].remote_ip, espconn->proto.tcp->remote_ip, 4) == 0) {
-			if (arg != connData[i].conn) connData[i].conn = arg; // yes, this happens!?
+			connData[i].conn=espconn;
 			return &connData[i];
 		}
 	}
@@ -280,7 +280,7 @@ int ICACHE_FLASH_ATTR cgiRedirectApClientToHostname(HttpdConnData *connData) {
 	int x=wifi_get_opmode();
 	//Check if we have an softap interface; bail out if not
 	if (x!=2 && x!=3) return HTTPD_CGI_NOTFOUND;
-	remadr=(uint32 *)connData->conn->proto.tcp->remote_ip;
+	remadr=(uint32 *)connData->remote_ip;
 	wifi_get_ip_info(SOFTAP_IF, &apip);
 	if ((*remadr & apip.netmask.addr) == (apip.ip.addr & apip.netmask.addr)) {
 		return cgiRedirectToHostname(connData);

--- a/core/httpd.c
+++ b/core/httpd.c
@@ -324,7 +324,6 @@ static void ICACHE_FLASH_ATTR httpdSentCb(void *arg) {
 	if (conn->cgi==NULL) { //Marked for destruction?
 		os_printf("Conn %p is done. Closing.\n", conn->conn);
 		espconn_disconnect(conn->conn);
-		httpdRetireConn(conn);
 		return; //No need to call httpdFlushSendBuffer.
 	}
 
@@ -545,23 +544,11 @@ static void ICACHE_FLASH_ATTR httpdReconCb(void *arg, sint8 err) {
 }
 
 static void ICACHE_FLASH_ATTR httpdDisconCb(void *arg) {
-	//The esp sdk passes through wrong arg here, namely the one of the *listening* socket.
-	//That is why we can't use (HttpdConnData)arg->sock here.
-	//Just look at all the sockets and kill the slot if needed.
-	int i;
-	for (i=0; i<MAX_CONN; i++) {
-		if (connData[i].conn!=NULL) {
-			//Why the >=ESPCONN_CLOSE and not ==? Well, seems the stack sometimes de-allocates
-			//espconns under our noses, especially when connections are interrupted. The memory
-			//is then used for something else, and we can use that to capture *most* of the
-			//disconnect cases.
-			if (connData[i].conn->state==ESPCONN_NONE || connData[i].conn->state>=ESPCONN_CLOSE) {
-				connData[i].conn=NULL;
-				if (connData[i].cgi!=NULL) connData[i].cgi(&connData[i]); //flush cgi data
-				httpdRetireConn(&connData[i]);
-			}
-		}
-	}
+	//The esp sdk passes the handle of the listening socket to us with the
+	//remote ip and port changed for the connection it is referring to.
+	HttpdConnData *conn=httpdFindConnData(arg);
+	if (conn==NULL) return;
+	httpdRetireConn(conn);
 }
 
 

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -34,6 +34,7 @@ struct HttpdConnData {
 	HttpdPostData *post;
 	int remote_port;
 	uint8 remote_ip[4];
+	uint8 slot;
 };
 
 //A struct describing the POST data sent inside the http connection.  This is used by the CGI functions


### PR DESCRIPTION
Patch description:
1. Handling of espconn disconnect changed so it is handled the way Espressif advised me on a different project.
2. Some cleanup that should not change behavior.
3. Pointers to espconn structures are irrelevant with Espressif's implementation.  Only remote IP/port positively identifies a socket connection.  The debugging information should reflect that.  Added slot information so the IP/port does not need to be repeated.

Please let me know what you think.  I've tested these changes in my environment and they work fine.
