### PR TITLE
Add option to not automatically send "Connection: close" header.

### DIFF
--- a/include/httpd.h
+++ b/include/httpd.h
@@ -64,6 +64,7 @@ int httpdFindArg(char *line, char *arg, char *buff, int buffLen);
 void httpdInit(HttpdBuiltInUrl *fixedUrls, int port);
 const char *httpdGetMimetype(char *url);
 void httpdDisableTransferEncoding(HttpdConnData *conn);
+void httpdNoAutoConnectionHeader(HttpdConnData *conn);
 void httpdStartResponse(HttpdConnData *conn, int code);
 void httpdHeader(HttpdConnData *conn, const char *field, const char *val);
 void httpdEndHeaders(HttpdConnData *conn);

--- a/util/cgiwebsocket.c
+++ b/util/cgiwebsocket.c
@@ -317,6 +317,7 @@ int ICACHE_FLASH_ATTR cgiWebsocket(HttpdConnData *connData) {
 				sha1_init(&s);
 				sha1_write(&s, buff, strlen(buff));
 				httpdDisableTransferEncoding(connData);
+				httpdNoAutoConnectionHeader(connData);
 				httpdStartResponse(connData, 101);
 				httpdHeader(connData, "Upgrade", "websocket");
 				httpdHeader(connData, "Connection", "upgrade");


### PR DESCRIPTION
Previously, when adding the "Connection: upgrade" header in the
websockets example, duplicate Connection headers were sent.
