### PR TITLE
Fix for zero-length files

### DIFF
--- a/espfs/mkespfsimage/main.c
+++ b/espfs/mkespfsimage/main.c
@@ -261,7 +261,7 @@ int handleFile(int f, char *name, int compression, int level, char **compName) {
 			*compName = "unknown";
 		}
 	}
-	return (csize*100)/size;
+	return size ? (csize*100)/size : 100;
 }
 
 //Write final dummy header with FLAG_LASTFILE set.


### PR DESCRIPTION
The mkespfsimage encoder was crashing on zero-length files due to trying to divide by file length.
This just always reports 100% (no compression) instead.
