### PR TITLE
Adding default content types for XML and JSON responses

### DIFF
--- a/core/httpd.c
+++ b/core/httpd.c
@@ -82,6 +82,8 @@ static const ICACHE_RODATA_ATTR MimeMap mimeTypes[]={
 	{"jpeg", "image/jpeg"},
 	{"png", "image/png"},
 	{"svg", "image/svg+xml"},
+	{"xml", "text/xml"},
+	{"json", "application/json"},
 	{NULL, "text/html"}, //default value
 };
 


### PR DESCRIPTION
This updates the default file extension -> content type mapping to include XML and JSON. I found having an XML template useful for returning a device description for the SSDP protocol (where you have to return a rather large XML document, with just one value generated dynamically), but needed this to get the content type header correct.

I also added JSON, since that is a common HTTP interchange format, and others might find it useful.
