### PR TITLE
Adding httpdContinue, to allow asynchronously resuming a request without sending data

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,13 @@ int ICACHE_FLASH_ATTR cgiSendLongString(HttpdConnData *connData) {
 
 ```
 
+In this case, the CGI is called again after each chunk of data has been sent over the socket. If you need to suspend the
+HTTP response and resume it asynchronously for some other reason, you may save the `HttpdConnData` pointer, return
+`HTTPD_CGI_MORE`, then later call `httpdContinue` with the saved connection pointer. For example, if you need to
+communicate with another device over a different connection, you could send data to that device in the initial CGI call,
+then return `HTTPD_CGI_MORE`, then, in the `espconn_recv_callback` for the response, you can call `httpdContinue` to
+resume the HTTP response with data retrieved from the other device.
+
 For POST data, a similar technique is used. For small amounts of POST data (smaller than MAX_POST, typically
 1024 bytes) the entire thing will be stored in `connData->post->buff` and is accessible in its entirely
 on the first call to the CGI function. For example, when using POST to send form data, if the amount of expected

--- a/core/httpd.c
+++ b/core/httpd.c
@@ -448,8 +448,14 @@ void ICACHE_FLASH_ATTR httpdCgiIsDone(HttpdConnData *conn) {
 //Callback called when the data on a socket has been successfully
 //sent.
 void ICACHE_FLASH_ATTR httpdSentCb(ConnTypePtr rconn, char *remIp, int remPort) {
-	int r;
 	HttpdConnData *conn=httpdFindConnData(rconn, remIp, remPort);
+	httpdContinue(conn);
+}
+
+//Can be called after a CGI function has returned HTTPD_CGI_MORE to
+//resume handling an open connection asynchronously
+void ICACHE_FLASH_ATTR httpdContinue(HttpdConnData * conn) {
+	int r;
 	char *sendBuff;
 
 	if (conn==NULL) return;

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -69,6 +69,7 @@ void httpdHeader(HttpdConnData *conn, const char *field, const char *val);
 void httpdEndHeaders(HttpdConnData *conn);
 int httpdGetHeader(HttpdConnData *conn, char *header, char *ret, int retLen);
 int httpdSend(HttpdConnData *conn, const char *data, int len);
+void httpdContinue(HttpdConnData *conn);
 void httpdFlushSendBuffer(HttpdConnData *conn);
 
 //Platform dependent code should call these.


### PR DESCRIPTION
Hopefully the change to the README makes the usage clear, but to provide a little more detail on my use-case:

I'm writing some firmware that proxies HTTP requests back to a device that uses a line-oriented TCP protocol with a persistent connection (a la Telnet). When I get an HTTP request, I need to issue a command to the other device, "pause" the HTTP connection, then resume it when I receive the response back from the other device, returning the received data.

Currently, I'm doing this by backing-up `connData->conn`, `connData->remote_ip` and `connData->remote_port`, then calling `httpdSentCb` with those values. This feels like I'm relying too much on an internal implementation detail, and it also results in an unnecessary call to `httpdFindConnData`.

This change just makes the resumption of a suspended connection an explicit function, and updates the sent callback to use that function. I'm not sure if there's any value in checking the send backlog when explicitly resuming like this, but it looks like it's not hurting anything, so feels like the most straightforward change.

(BTW, thanks for a great library. It's shaved many nights of work off my little toy project, and got me going quickly!)
