### PR TITLE
fix symbol conflict with sdk bultin base64

### DIFF
--- a/core/auth.c
+++ b/core/auth.c
@@ -31,7 +31,7 @@ int ICACHE_FLASH_ATTR authBasic(HttpdConnData *connData) {
 
 	r=httpdGetHeader(connData, "Authorization", hdr, sizeof(hdr));
 	if (r && strncmp(hdr, "Basic", 5)==0) {
-		r=base64_decode(strlen(hdr)-6, hdr+6, sizeof(userpass), (unsigned char *)userpass);
+		r=user_base64_decode(strlen(hdr)-6, hdr+6, sizeof(userpass), (unsigned char *)userpass);
 		if (r<0) r=0; //just clean out string on decode error
 		userpass[r]=0; //zero-terminate user:pass string
 //		printf("Auth: %s\n", userpass);

--- a/core/base64.c
+++ b/core/base64.c
@@ -39,7 +39,7 @@ static int ICACHE_FLASH_ATTR base64decode(const char in[4], char out[3]) {
 #endif
 
 /* decode a base64 string in one shot */
-int ICACHE_FLASH_ATTR base64_decode(size_t in_len, const char *in, size_t out_len, unsigned char *out) {
+int ICACHE_FLASH_ATTR user_base64_decode(size_t in_len, const char *in, size_t out_len, unsigned char *out) {
 	unsigned int ii, io;
 	uint32_t v;
 	unsigned int rem;
@@ -77,7 +77,7 @@ void base64encode(const unsigned char in[3], unsigned char out[4], int count) {
 }
 #endif
 
-int ICACHE_FLASH_ATTR base64_encode(size_t in_len, const unsigned char *in, size_t out_len, char *out) {
+int ICACHE_FLASH_ATTR user_base64_encode(size_t in_len, const unsigned char *in, size_t out_len, char *out) {
 	unsigned ii, io;
 	uint32_t v;
 	unsigned rem;

--- a/core/base64.h
+++ b/core/base64.h
@@ -1,6 +1,6 @@
 #ifndef BASE64_H
 #define BASE64_H
 
-int base64_decode(size_t in_len, const char *in, size_t out_len, unsigned char *out);
-int base64_encode(size_t in_len, const unsigned char *in, size_t out_len, char *out);
+int user_base64_decode(size_t in_len, const char *in, size_t out_len, unsigned char *out);
+int user_base64_encode(size_t in_len, const unsigned char *in, size_t out_len, char *out);
 #endif

--- a/util/cgiwebsocket.c
+++ b/util/cgiwebsocket.c
@@ -324,7 +324,7 @@ int ICACHE_FLASH_ATTR cgiWebsocket(HttpdConnData *connData) {
 				httpdStartResponse(connData, 101);
 				httpdHeader(connData, "Upgrade", "websocket");
 				httpdHeader(connData, "Connection", "upgrade");
-				base64_encode(20, sha1_result(&s), sizeof(buff), buff);
+				user_base64_encode(20, sha1_result(&s), sizeof(buff), buff);
 				httpdHeader(connData, "Sec-WebSocket-Accept", buff);
 				httpdEndHeaders(connData);
 				//Set data receive handler


### PR DESCRIPTION
There is a base64_encode/base64_decode symbol conflict with the sdk.  This is a workaround for it.
