### PR TITLE
espmissingincludes.h: adjust prototypes for SDK 2.x compatibility

### DIFF
--- a/include/espmissingincludes.h
+++ b/include/espmissingincludes.h
@@ -9,13 +9,14 @@ int strcasecmp(const char *a, const char *b);
 #ifndef FREERTOS
 #include <eagle_soc.h>
 #include <ets_sys.h>
+
 //Missing function prototypes in include folders. Gcc will warn on these if we don't define 'em anywhere.
 //MOST OF THESE ARE GUESSED! but they seem to swork and shut up the compiler.
 typedef struct espconn espconn;
 
 int atoi(const char *nptr);
-void ets_install_putc1(void *routine);
-void ets_isr_attach(int intr, void *handler, void *arg);
+void ets_install_putc1(void (*routine)(char c));
+void ets_isr_attach(int intr, void (*handler)(void *), void *arg);
 void ets_isr_mask(unsigned intr);
 void ets_isr_unmask(unsigned intr);
 int ets_memcmp(const void *s1, const void *s2, size_t n);
@@ -25,11 +26,11 @@ int ets_sprintf(char *str, const char *format, ...)  __attribute__ ((format (pri
 int ets_str2macaddr(void *, void *);
 int ets_strcmp(const char *s1, const char *s2);
 char *ets_strcpy(char *dest, const char *src);
-size_t ets_strlen(const char *s);
-int ets_strncmp(const char *s1, const char *s2, int len);
+int ets_strlen(const char *s);
+int ets_strncmp(const char *s1, const char *s2, unsigned int len);
 char *ets_strncpy(char *dest, const char *src, size_t n);
 char *ets_strstr(const char *haystack, const char *needle);
-void ets_timer_arm_new(os_timer_t *a, int b, int c, int isMstimer);
+void ets_timer_arm_new(os_timer_t *a, uint32_t b, bool repeat, bool isMstimer);
 void ets_timer_disarm(os_timer_t *a);
 void ets_timer_setfn(os_timer_t *t, ETSTimerFunc *fn, void *parg);
 void ets_update_cpu_frequency(int freqmhz);
@@ -37,12 +38,12 @@ void *os_memmove(void *dest, const void *src, size_t n);
 int os_printf(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
 int os_snprintf(char *str, size_t size, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
 int os_printf_plus(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
-void uart_div_modify(int no, unsigned int freq);
+void uart_div_modify(uint8 no, uint32 freq);
 uint8 wifi_get_opmode(void);
 uint32 system_get_time();
 int rand(void);
 void ets_bzero(void *s, size_t n);
-void ets_delay_us(int ms);
+void ets_delay_us(uint16_t ms);
 
 //Hack: this is defined in SDK 1.4.0 and undefined in 1.3.0. It's only used for this, the symbol itself
 //has no meaning here.
@@ -54,11 +55,11 @@ void vPortFree(void *ptr);
 void *vPortMalloc(size_t xWantedSize);
 void pvPortFree(void *ptr);
 #else
-void *pvPortMalloc(size_t xWantedSize, const char *file, int line);
-void *pvPortZalloc(size_t, const char *file, int line);
-void vPortFree(void *ptr, const char *file, int line);
-void *vPortMalloc(size_t xWantedSize, const char *file, int line);
-void pvPortFree(void *ptr, const char *file, int line);
+void *pvPortMalloc(size_t xWantedSize, const char *file, unsigned line);
+void *pvPortZalloc(size_t, const char *file, unsigned line);
+void vPortFree(void *ptr, const char *file, unsigned line);
+void *vPortMalloc(size_t xWantedSize, const char *file, unsigned line);
+void pvPortFree(void *ptr, const char *file, unsigned line);
 #endif
 
 //Standard PIN_FUNC_SELECT gives a warning. Replace by a non-warning one.


### PR DESCRIPTION
SDK 2.x provides prototypes for some of the functions listed here, but with
slightly different argument types, leading to build errors:

In file included from ./include/esp8266.h:33:0,
                 from espfs/espfs.c:23:
./include/espmissingincludes.h:17:6: error: conflicting types for 'ets_install_putc1'
 void ets_install_putc1(void *routine);
      ^
In file included from ./include/esp8266.h:27:0,
                 from espfs/espfs.c:23:
/opt/esp-open-sdk/sdk/include/osapi.h:34:6: note: previous declaration of 'ets_install_putc1' was here
 void ets_install_putc1(void (*p)(char c));
      ^
In file included from ./include/esp8266.h:33:0,
                 from espfs/espfs.c:23:
./include/espmissingincludes.h:18:6: error: conflicting types for 'ets_isr_attach'
 void ets_isr_attach(int intr, void *handler, void *arg);
      ^
In file included from ./include/esp8266.h:24:0,
                 from espfs/espfs.c:23:
/opt/esp-open-sdk/sdk/include/ets_sys.h:67:6: note: previous declaration of 'ets_isr_attach' was here
 void ets_isr_attach(int i, ets_isr_t func, void *arg);
      ^
In file included from ./include/esp8266.h:33:0,
                 from espfs/espfs.c:23:
./include/espmissingincludes.h:28:8: error: conflicting types for 'ets_strlen'
 size_t ets_strlen(const char *s);
        ^
In file included from ./include/esp8266.h:27:0,
                 from espfs/espfs.c:23:
/opt/esp-open-sdk/sdk/include/osapi.h:47:5: note: previous declaration of 'ets_strlen' was here
 int ets_strlen(const char *s);
     ^
In file included from ./include/esp8266.h:33:0,
                 from espfs/espfs.c:23:
./include/espmissingincludes.h:29:5: error: conflicting types for 'ets_strncmp'
 int ets_strncmp(const char *s1, const char *s2, int len);
     ^
In file included from ./include/esp8266.h:27:0,
                 from espfs/espfs.c:23:
/opt/esp-open-sdk/sdk/include/osapi.h:48:5: note: previous declaration of 'ets_strncmp' was here
 int ets_strncmp(const char *s1, const char *s2, unsigned int n);
     ^
In file included from ./include/esp8266.h:33:0,
                 from espfs/espfs.c:23:
./include/espmissingincludes.h:32:6: error: conflicting types for 'ets_timer_arm_new'
 void ets_timer_arm_new(os_timer_t *a, int b, int c, int isMstimer);
      ^
In file included from ./include/esp8266.h:27:0,
                 from espfs/espfs.c:23:
/opt/esp-open-sdk/sdk/include/osapi.h:65:6: note: previous declaration of 'ets_timer_arm_new' was here
 void ets_timer_arm_new(os_timer_t *ptimer, uint32_t time, bool repeat_flag, bool ms_flag);
      ^
In file included from ./include/esp8266.h:33:0,
                 from espfs/espfs.c:23:
./include/espmissingincludes.h:40:6: error: conflicting types for 'uart_div_modify'
 void uart_div_modify(int no, unsigned int freq);
      ^
In file included from ./include/esp8266.h:28:0,
                 from espfs/espfs.c:23:
/opt/esp-open-sdk/sdk/include/user_interface.h:646:6: note: previous declaration of 'uart_div_modify' was here
 void uart_div_modify(uint8 uart_no, uint32 DivLatchValue);
      ^
In file included from ./include/esp8266.h:33:0,
                 from espfs/espfs.c:23:
./include/espmissingincludes.h:45:6: error: conflicting types for 'ets_delay_us'
 void ets_delay_us(int ms);
      ^
In file included from ./include/esp8266.h:27:0,
                 from espfs/espfs.c:23:
/opt/esp-open-sdk/sdk/include/osapi.h:33:6: note: previous declaration of 'ets_delay_us' was here
 void ets_delay_us(uint16_t us);
      ^
In file included from ./include/esp8266.h:33:0,
                 from espfs/espfs.c:23:
./include/espmissingincludes.h:57:7: error: conflicting types for 'pvPortMalloc'
 void *pvPortMalloc(size_t xWantedSize, const char *file, int line);
       ^
In file included from ./include/esp8266.h:26:0,
                 from espfs/espfs.c:23:
/home/peko/source/esp8266/esp-open-sdk/sdk//include/mem.h:38:7: note: previous declaration of 'pvPortMalloc' was here
 void *pvPortMalloc (size_t sz, const char *, unsigned);
       ^
In file included from ./include/esp8266.h:33:0,
                 from espfs/espfs.c:23:
./include/espmissingincludes.h:58:7: error: conflicting types for 'pvPortZalloc'
 void *pvPortZalloc(size_t, const char *file, int line);
       ^
In file included from ./include/esp8266.h:26:0,
                 from espfs/espfs.c:23:
/opt/esp-open-sdk/sdk/include/mem.h:40:7: note: previous declaration of 'pvPortZalloc' was here
 void *pvPortZalloc (size_t sz, const char *, unsigned);
       ^
In file included from ./include/esp8266.h:33:0,
                 from espfs/espfs.c:23:
./include/espmissingincludes.h:59:6: error: conflicting types for 'vPortFree'
 void vPortFree(void *ptr, const char *file, int line);
      ^
In file included from ./include/esp8266.h:26:0,
                 from espfs/espfs.c:23:
/opt/esp-open-sdk/sdk/include/mem.h:39:6: note: previous declaration of 'vPortFree' was here
 void vPortFree (void *p, const char *, unsigned);
      ^

Adjust the prototypes here to match the SDK to fix these issues.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>