### PR TITLE
Argument type conflict in NONOS_SDK-2.2.0

### DIFF
--- a/include/espmissingincludes.h
+++ b/include/espmissingincludes.h
@@ -43,7 +43,7 @@ uint8 wifi_get_opmode(void);
 uint32 system_get_time();
 int rand(void);
 void ets_bzero(void *s, size_t n);
-void ets_delay_us(uint16_t ms);
+//void ets_delay_us(uint16_t ms);
 
 //Hack: this is defined in SDK 1.4.0 and undefined in 1.3.0. It's only used for this, the symbol itself
 //has no meaning here.


### PR DESCRIPTION
While compiling with ESP8266_NONOS_SDK-2.2.0 it was
found that the SDK defines the function, `void ets_delay_us(uint32_t ms)`
(in SDK root, include/osapi.h) which is defined in
include/espmissingincludes.h as `void ets_delay_us(uint16_t ms)` which
results in the following error:

```
CC espfs/espfs.c
In file included from ./include/esp8266.h:33:0,
                 from espfs/espfs.c:23:
./include/espmissingincludes.h:46:6: error: conflicting types for 'ets_delay_us'
 void ets_delay_us(uint16_t ms);
      ^
In file included from ./include/esp8266.h:28:0,
                 from espfs/espfs.c:23:
..//include/osapi.h:33:6: note: previous declaration of 'ets_delay_us' was here
 void ets_delay_us(uint32_t us);
      ^
```

Commenting out the function prototype from espmissingincludes.h fixes
the problem.